### PR TITLE
Fix Vercel routing for static assets

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,7 @@
     }
   ],
   "routes": [
+    { "handle": "filesystem" },
     { "src": "/.*", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- ensure static files are served before SPA fallback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688eab4303688324888a2efd5a767d20